### PR TITLE
WiFi.begin(ssid, pass) needs time to return WL_CONNECTED

### DIFF
--- a/examples/simplesample_mqtt/simplesample_mqtt.ino
+++ b/examples/simplesample_mqtt/simplesample_mqtt.ino
@@ -97,9 +97,13 @@ void initWifi() {
 
     // Connect to WPA/WPA2 network. Change this line if using open or WEP network:
     while (WiFi.begin(ssid, pass) != WL_CONNECTED) {
-        // unsuccessful, retry in 4 seconds
+        //just give WiFi.begin some time to return WL_CONNECTED, before saying it failed...
+        delay(5000);
+        if (WiFi.status() == WL_CONNECTED) {
+            break;
+        }
+        //retrying...
         Serial.print("failed ... ");
-        delay(4000);
         Serial.print("retrying ... ");
     }
 


### PR DESCRIPTION
The ESP libs for WiFi take a bit longer to initiate and return a WL_CONNECTED. Added a longer delay before checking if WL_CONNECTED and breaking the while loop.

Same issue as with the [simplesample_http sample](https://github.com/Azure/azure-iot-arduino/pull/42).